### PR TITLE
feat: add word wrap toggle for code previews (Ctrl+W)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Kglance offers rich keyboard navigation for navigating files, zooming images, sc
 | `Ctrl` + `C`                  | Copy file path / Copy selected text            | Global / Text preview        |
 | `Ctrl` + `A`                  | Select all text                                | Text / Code preview          |
 | `Ctrl` + `F`                  | Open text search bar                           | Text / Code preview          |
-| `Ctrl` + `W`                  | Toggle line word wrap                          | Text / Code preview          |
+| `Ctrl` + `W`                  | Toggle word wrap                               | Text / Code / JSON preview   |
 | `Ctrl` + `+` / `Ctrl` + `=`   | Zoom in / Increase font size                   | Image / PDF / Text preview   |
 | `Ctrl` + `-`                  | Zoom out / Decrease font size                  | Image / PDF / Text preview   |
 | `Ctrl` + `0`                  | Reset zoom to 100%                             | Image preview                |
@@ -195,7 +195,8 @@ The config file is auto-created with defaults on first run. See `data/examples/c
     "font_family_mono": "Fira Code",
     "epub_font_family": "Noto Serif",
     "max_text_width": 820.0,
-    "prefer_mermaid_cli": false
+    "prefer_mermaid_cli": false,
+    "word_wrap": false
   }
 }
 ```

--- a/data/examples/config.example.json
+++ b/data/examples/config.example.json
@@ -10,6 +10,7 @@
     "font_family_mono": "Fira Code",
     "epub_font_family": "Noto Serif",
     "max_text_width": 820.0,
-    "prefer_mermaid_cli": false
+    "prefer_mermaid_cli": false,
+    "word_wrap": false
   }
 }

--- a/src/app/keyboard/ctrl.rs
+++ b/src/app/keyboard/ctrl.rs
@@ -61,6 +61,18 @@ impl KglanceApp {
             "P" if matches!(self.current_content, Some(PreviewData::Json { .. })) => Some(
                 Task::done(crate::app::messages::JsonMsg::ToggleFormat.into()),
             ),
+            "w" | "W" if matches!(
+                self.current_content,
+                Some(PreviewData::Text { .. })
+                    | Some(PreviewData::Json { .. })
+                    | Some(PreviewData::Typst { .. })
+            ) => {
+                self.state.word_wrap = !self.state.word_wrap;
+                let mut config = crate::core::config::ConfigManager::load_or_create();
+                config.ui.word_wrap = self.state.word_wrap;
+                let _ = crate::core::config::ConfigManager::save(&config);
+                Some(Task::none())
+            }
             _ => None,
         }
     }

--- a/src/app/messages.rs
+++ b/src/app/messages.rs
@@ -200,6 +200,7 @@ pub enum SettingsMsg {
     DefaultHeightChanged(u32),
     MinWidthChanged(u32),
     MinHeightChanged(u32),
+    WordWrapChanged(bool),
 }
 
 #[derive(Debug, Clone)]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -77,6 +77,7 @@ impl KglanceApp {
                 config.ui.min_height as f32,
             ),
             prefer_mermaid_cli: config.ui.prefer_mermaid_cli,
+            word_wrap: config.ui.word_wrap,
 
             ..Default::default()
         };
@@ -475,6 +476,7 @@ impl KglanceApp {
                     self.state.app_theme,
                     self.state.font_size,
                     self.state.font_family_mono.as_deref(),
+                    self.state.word_wrap,
                 ),
                 PreviewData::Markdown { blocks, .. } => crate::ui::views::view_markdown(
                     blocks,
@@ -499,6 +501,7 @@ impl KglanceApp {
                     self.state.app_theme,
                     self.state.font_size,
                     self.state.font_family_mono.as_deref(),
+                    self.state.word_wrap,
                 ),
                 PreviewData::Folder { .. } => {
                     crate::ui::views::view_folder(&self.state.folder, self.state.app_theme)
@@ -512,6 +515,7 @@ impl KglanceApp {
                     self.state.font_size,
                     self.state.app_theme,
                     self.state.font_family_mono.as_deref(),
+                    self.state.word_wrap,
                 ),
                 PreviewData::Epub { .. } => crate::ui::views::view_epub(
                     &self.state.epub,

--- a/src/app/update/mod.rs
+++ b/src/app/update/mod.rs
@@ -393,6 +393,13 @@ pub fn update(app: &mut KglanceApp, message: Message) -> Task<Message> {
                 let _ = crate::core::config::ConfigManager::save(&config);
                 Task::none()
             }
+            crate::app::messages::SettingsMsg::WordWrapChanged(enabled) => {
+                app.state.word_wrap = enabled;
+                let mut config = crate::core::config::ConfigManager::load_or_create();
+                config.ui.word_wrap = enabled;
+                let _ = crate::core::config::ConfigManager::save(&config);
+                Task::none()
+            }
         },
 
         // Global Layout / Input Events

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -18,6 +18,8 @@ pub struct UiConfig {
     pub min_height: u32,
     #[serde(default)]
     pub prefer_mermaid_cli: bool,
+    #[serde(default)]
+    pub word_wrap: bool,
 }
 
 fn default_min_width() -> u32 {
@@ -77,6 +79,7 @@ impl Default for UiConfig {
             min_width: default_min_width(),
             min_height: default_min_height(),
             prefer_mermaid_cli: false,
+            word_wrap: false,
         }
     }
 }
@@ -112,11 +115,19 @@ impl ConfigManager {
 
     pub fn load_or_create() -> AppConfig {
         let path = Self::get_config_path();
-        let loaded = fs::read_to_string(&path)
-            .ok()
-            .and_then(|content| serde_json::from_str::<AppConfig>(&content).ok());
+        let raw = fs::read_to_string(&path).ok();
+
+        let loaded = raw
+            .as_deref()
+            .and_then(|content| serde_json::from_str::<AppConfig>(content).ok());
 
         if let Some(config) = loaded {
+            let reserialized = serde_json::to_string_pretty(&config).unwrap_or_default();
+            if raw.as_deref() != Some(reserialized.as_str()) {
+                if let Err(e) = Self::save(&config) {
+                    eprintln!("[kglance] failed to update config: {e}");
+                }
+            }
             return config;
         }
 

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -507,6 +507,7 @@ pub struct KglanceState {
     pub toasts: Vec<ToastInfo>,
     pub next_toast_id: u64,
     pub prefer_mermaid_cli: bool,
+    pub word_wrap: bool,
     pub current_window_size: iced::Size,
 }
 
@@ -564,6 +565,7 @@ impl Default for KglanceState {
             toasts: Vec::new(),
             next_toast_id: 0,
             prefer_mermaid_cli: false,
+            word_wrap: false,
             current_window_size: iced::Size::new(1024.0, 768.0),
         }
     }

--- a/src/features/json/view/components.rs
+++ b/src/features/json/view/components.rs
@@ -138,6 +138,7 @@ pub fn render_raw<'a>(
     theme: AppTheme,
     font_size: f32,
     font_family_mono: Option<&str>,
+    word_wrap: bool,
 ) -> Element<'a, Message> {
     let mono_font = match font_family_mono {
         Some(name) => iced::Font::with_name(Box::leak(name.to_string().into_boxed_str())),
@@ -150,6 +151,7 @@ pub fn render_raw<'a>(
         theme,
         font_size,
         mono_font,
+        word_wrap,
         |action| crate::app::messages::JsonMsg::RawEdit(action).into(),
     )
 }

--- a/src/features/json/view/mod.rs
+++ b/src/features/json/view/mod.rs
@@ -20,6 +20,7 @@ pub fn view_json<'a>(
     font_size: f32,
     theme: crate::ui::theme::AppTheme,
     font_family_mono: Option<&str>,
+    word_wrap: bool,
 ) -> Element<'a, Message> {
     let toggle_label = if state.tree_mode { "Raw" } else { "Tree" };
 
@@ -125,7 +126,7 @@ pub fn view_json<'a>(
             .container_padding(4)
             .build()
     } else {
-        let raw = render_raw(state, theme, font_size, font_family_mono);
+        let raw = render_raw(state, theme, font_size, font_family_mono, word_wrap);
         scroll_pane("json_raw_scroll", raw)
             .container_padding(4)
             .build()

--- a/src/features/text/view.rs
+++ b/src/features/text/view.rs
@@ -19,6 +19,7 @@ pub fn view_text<'a>(
     theme: crate::ui::theme::AppTheme,
     font_size: f32,
     font_family_mono: Option<&str>,
+    word_wrap: bool,
 ) -> Element<'a, Message> {
     let font = get_code_font(font_family_mono);
     let mut main_content = column![].spacing(MAIN_CONTENT_SPACING);
@@ -37,6 +38,7 @@ pub fn view_text<'a>(
         theme,
         font_size,
         font,
+        word_wrap,
         |action| crate::app::messages::TextMsg::Edit(action).into(),
     );
 

--- a/src/features/typst/view.rs
+++ b/src/features/typst/view.rs
@@ -15,6 +15,7 @@ pub fn view_typst<'a>(
     theme: crate::ui::theme::AppTheme,
     font_size: f32,
     font_family_mono: Option<&str>,
+    word_wrap: bool,
 ) -> Element<'a, Message> {
     if state.show_source || state.error.is_some() {
         let font = get_code_font(font_family_mono);
@@ -24,6 +25,7 @@ pub fn view_typst<'a>(
             theme,
             font_size,
             font,
+            word_wrap,
             ignore_editor_action,
         );
 

--- a/src/ui/components/code_editor.rs
+++ b/src/ui/components/code_editor.rs
@@ -76,6 +76,7 @@ pub fn code_editor<'a>(
     theme: AppTheme,
     font_size: f32,
     font: Font,
+    word_wrap: bool,
     on_action: fn(Action) -> Message,
 ) -> Element<'a, Message> {
     let highlight_theme = select_highlight_theme(theme);
@@ -106,17 +107,27 @@ pub fn code_editor<'a>(
         .highlight(&syntax, highlight_theme)
         .font(font)
         .size(font_size)
-        .wrapping(iced::widget::text::Wrapping::None)
+        .wrapping(if word_wrap {
+            iced::widget::text::Wrapping::Word
+        } else {
+            iced::widget::text::Wrapping::None
+        })
         .on_action(on_action)
         .style(default_text_editor);
 
-    row![
-        container(line_numbers_widget).align_y(Vertical::Top),
-        editor_widget
-    ]
-    .spacing(GUTTER_SPACING)
-    .align_y(Alignment::Start)
-    .into()
+    if word_wrap {
+        row![editor_widget]
+            .align_y(Alignment::Start)
+            .into()
+    } else {
+        row![
+            container(line_numbers_widget).align_y(Vertical::Top),
+            editor_widget
+        ]
+        .spacing(GUTTER_SPACING)
+        .align_y(Alignment::Start)
+        .into()
+    }
 }
 
 #[cfg(test)]

--- a/src/ui/views/setting_page/mod.rs
+++ b/src/ui/views/setting_page/mod.rs
@@ -7,7 +7,8 @@ use crate::core::config::UiConfig;
 use crate::ui::theme::color::BaseColors;
 use crate::ui::theme::tokens::spacing;
 use crate::ui::theme::{
-    default_button, default_card, default_pick_list, default_slider, default_text_input,
+    default_button, default_card, default_checkbox, default_pick_list, default_slider,
+    default_text_input,
 };
 
 const TITLE_FONT_SIZE: f32 = 18.0;
@@ -79,6 +80,7 @@ pub fn settings_page<'a>(
             |font| Message::Settings(SettingsMsg::EpubFontFamilySelected(font))
         ),
         build_reader_width_section(theme, config),
+        build_word_wrap_section(theme, config),
         build_dimension_input_section(
             theme,
             "Default Window Size (Width × Height)",
@@ -225,6 +227,19 @@ fn build_reader_width_section<'a>(theme: &Theme, config: &'a UiConfig) -> Elemen
 
     column![label, slider_widget].spacing(spacing::XS).into()
 }
+fn build_word_wrap_section<'a>(theme: &Theme, config: &'a UiConfig) -> Element<'a, Message> {
+    let theme_clone = theme.clone();
+    let checkbox_widget = iced::widget::checkbox(config.word_wrap)
+        .label("Word Wrap in Code Previews (Ctrl+W)")
+        .on_toggle(|enabled| Message::Settings(SettingsMsg::WordWrapChanged(enabled)))
+        .text_size(SECTION_FONT_SIZE)
+        .style(move |_, status| default_checkbox(&theme_clone, status));
+
+    column![checkbox_widget]
+        .spacing(spacing::XS)
+        .into()
+}
+
 #[allow(clippy::too_many_arguments)]
 fn build_dimension_input_section<'a, FW, FH>(
     theme: &Theme,

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -256,6 +256,7 @@ pub fn view_window<'a>(
                 min_width: state.window_min_size.width as u32,
                 min_height: state.window_min_size.height as u32,
                 prefer_mermaid_cli: state.prefer_mermaid_cli,
+                word_wrap: state.word_wrap,
             }));
 
         let static_fonts: &'static [String] =

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -54,6 +54,7 @@ fn test_config_serialization_round_trip() {
             min_width: 800,
             min_height: 600,
             prefer_mermaid_cli: false,
+            word_wrap: false,
         },
     };
     let json = serde_json::to_string_pretty(&config).unwrap();


### PR DESCRIPTION
## Summary

- Implement the word wrap toggle (`Ctrl+W`) that was documented in the README but not yet functional
- Add `word_wrap` as a persistent setting in the config file and Settings UI (checkbox)
- When word wrap is enabled, line numbers are hidden to avoid misalignment with visually wrapped lines
- Existing config files are automatically backfilled with the new `word_wrap` field on app launch via `serde(default)` + re-save on load

### Changes across 16 files:

- **Config**: `word_wrap: bool` added to `UiConfig` with `#[serde(default)]`; `load_or_create()` re-saves config when deserialized output differs from file (backfills missing fields)
- **Keyboard**: `Ctrl+W` handler for Text/JSON/Typst previews toggles `word_wrap` and persists to config
- **Settings UI**: Word wrap checkbox in settings page
- **Code editor**: Conditional `Wrapping::Word` / `Wrapping::None`; gutter hidden when word wrap active
- **Views**: `word_wrap` param threaded through `view_text`, `view_json`, `view_typst`
- **Docs**: README and example config updated

## Test plan

- [x] `cargo check` passes
- [ ] Open text/code file → `Ctrl+W` toggles word wrap on/off
- [ ] Long lines wrap correctly with word wrap enabled
- [ ] Line numbers hidden when word wrap on, visible when off
- [ ] Settings page checkbox reflects and toggles word wrap state
- [ ] Config file auto-updates with `word_wrap` field on first launch after upgrade
- [ ] Fresh install creates config with `word_wrap: false`

---

This code was authored by Claude (Anthropic AI assistant), prompted by @nabaxo.