### PR TITLE
feat: add Krita (.kra) and OpenRaster (.ora) file preview

### DIFF
--- a/src/engine/registry.rs
+++ b/src/engine/registry.rs
@@ -8,6 +8,7 @@ pub fn build_registry() -> ParserRegistry {
     r.register(Box::new(features::text::parser::TextParser::new()));
     r.register(Box::new(features::image::parser::ImageParser));
     r.register(Box::new(features::svg::parser::SvgParser));
+    r.register(Box::new(features::krita::parser::KritaParser));
     r.register(Box::new(features::pdf::parser::PdfParser));
     r.register(Box::new(features::archive::ArchiveParser));
     r.register(Box::new(features::folder::parser::FolderParser));

--- a/src/features/krita/mod.rs
+++ b/src/features/krita/mod.rs
@@ -1,0 +1,1 @@
+pub mod parser;

--- a/src/features/krita/parser.rs
+++ b/src/features/krita/parser.rs
@@ -1,0 +1,60 @@
+use std::io::Read;
+use std::path::Path;
+
+use crate::features::common::parser::traits::{ParseError, PreviewParser};
+use crate::features::common::parser::types::ParsedContent;
+use crate::features::image::types::ImageFormat;
+
+pub struct KritaParser;
+
+impl PreviewParser for KritaParser {
+    fn supported_extensions(&self) -> &[&str] {
+        &["kra", "ora"]
+    }
+
+    fn parse(&self, path: &Path) -> Result<ParsedContent, ParseError> {
+        let file =
+            std::fs::File::open(path).map_err(|e| ParseError::ParseFailed(e.to_string()))?;
+        let mut archive =
+            zip::ZipArchive::new(file).map_err(|e| ParseError::ParseFailed(e.to_string()))?;
+
+        let mut entry = archive
+            .by_name("mergedimage.png")
+            .map_err(|_| ParseError::ParseFailed("no mergedimage.png in archive".into()))?;
+
+        let mut png_data = Vec::new();
+        entry
+            .read_to_end(&mut png_data)
+            .map_err(|e| ParseError::ParseFailed(e.to_string()))?;
+
+        let cursor = std::io::Cursor::new(&png_data);
+        let reader = image::ImageReader::new(cursor)
+            .with_guessed_format()
+            .map_err(|e| ParseError::ParseFailed(e.to_string()))?;
+        let (width, height) = reader
+            .into_dimensions()
+            .map_err(|e| ParseError::ParseFailed(e.to_string()))?;
+
+        Ok(ParsedContent::Image {
+            data: png_data,
+            width,
+            height,
+            format: ImageFormat::Png,
+            exif: None,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn supports_kra_and_ora_extensions() {
+        let parser = KritaParser;
+        assert!(parser.is_supported(Path::new("drawing.kra")));
+        assert!(parser.is_supported(Path::new("painting.ora")));
+        assert!(!parser.is_supported(Path::new("image.png")));
+        assert!(!parser.is_supported(Path::new("file.xcf")));
+    }
+}

--- a/src/features/krita/parser.rs
+++ b/src/features/krita/parser.rs
@@ -1,4 +1,5 @@
-use std::io::Read;
+use std::fs;
+use std::io::{BufReader, Read};
 use std::path::Path;
 
 use crate::features::common::parser::traits::{ParseError, PreviewParser};
@@ -13,27 +14,9 @@ impl PreviewParser for KritaParser {
     }
 
     fn parse(&self, path: &Path) -> Result<ParsedContent, ParseError> {
-        let file =
-            std::fs::File::open(path).map_err(|e| ParseError::ParseFailed(e.to_string()))?;
-        let mut archive =
-            zip::ZipArchive::new(file).map_err(|e| ParseError::ParseFailed(e.to_string()))?;
-
-        let mut entry = archive
-            .by_name("mergedimage.png")
-            .map_err(|_| ParseError::ParseFailed("no mergedimage.png in archive".into()))?;
-
-        let mut png_data = Vec::new();
-        entry
-            .read_to_end(&mut png_data)
-            .map_err(|e| ParseError::ParseFailed(e.to_string()))?;
-
-        let cursor = std::io::Cursor::new(&png_data);
-        let reader = image::ImageReader::new(cursor)
-            .with_guessed_format()
-            .map_err(|e| ParseError::ParseFailed(e.to_string()))?;
-        let (width, height) = reader
-            .into_dimensions()
-            .map_err(|e| ParseError::ParseFailed(e.to_string()))?;
+        let mut archive = open_archive(path)?;
+        let png_data = read_preview_image(&mut archive)?;
+        let (width, height) = read_image_dimensions(&png_data)?;
 
         Ok(ParsedContent::Image {
             data: png_data,
@@ -43,6 +26,45 @@ impl PreviewParser for KritaParser {
             exif: None,
         })
     }
+}
+
+fn open_archive(path: &Path) -> Result<zip::ZipArchive<BufReader<std::fs::File>>, ParseError> {
+    let file = fs::File::open(path).map_err(|error| ParseError::ParseFailed(error.to_string()))?;
+    zip::ZipArchive::new(BufReader::new(file))
+        .map_err(|error| ParseError::ParseFailed(error.to_string()))
+}
+
+fn read_preview_image<R: Read + std::io::Seek>(
+    archive: &mut zip::ZipArchive<R>,
+) -> Result<Vec<u8>, ParseError> {
+    for entry_name in ["mergedimage.png", "preview.png"] {
+        match archive.by_name(entry_name) {
+            Ok(mut entry) => {
+                let mut image_data = Vec::new();
+                entry
+                    .read_to_end(&mut image_data)
+                    .map_err(|error| ParseError::ParseFailed(error.to_string()))?;
+
+                return Ok(image_data);
+            }
+            Err(zip::result::ZipError::FileNotFound) => continue,
+            Err(error) => return Err(ParseError::ParseFailed(error.to_string())),
+        }
+    }
+
+    Err(ParseError::ParseFailed(
+        "No preview image found in archive".to_string(),
+    ))
+}
+
+fn read_image_dimensions(image_data: &[u8]) -> Result<(u32, u32), ParseError> {
+    let reader = image::ImageReader::new(std::io::Cursor::new(image_data))
+        .with_guessed_format()
+        .map_err(|error| ParseError::ParseFailed(error.to_string()))?;
+
+    reader
+        .into_dimensions()
+        .map_err(|error| ParseError::ParseFailed(error.to_string()))
 }
 
 #[cfg(test)]

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -9,6 +9,7 @@ pub mod grid;
 
 pub mod image;
 pub mod json;
+pub mod krita;
 pub mod markdown;
 pub mod office;
 pub mod pdf;

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,17 +153,9 @@ fn run_standalone(paths: &[String]) -> Result<(), Box<dyn std::error::Error>> {
         config.ui.default_width as f32,
         config.ui.default_height as f32,
     );
-    let ext = resolved
-        .extension()
-        .and_then(|e| e.to_str())
-        .unwrap_or("")
-        .to_lowercase();
-    let image_extensions = [
-        "png", "jpg", "jpeg", "gif", "bmp", "webp", "tiff", "tif", "ico", "svg",
-    ];
-    if image_extensions.contains(&ext.as_str())
-        && let Ok(kglance::parsers::ParsedContent::Image { width, height, .. }) =
-            registry.parse(resolved)
+
+    if let Ok(kglance::parsers::ParsedContent::Image { width, height, .. }) =
+        registry.parse(resolved)
     {
         initial_size = kglance::features::image::view::calculate_window_size(
             config.ui.default_width as f32,


### PR DESCRIPTION
## Summary

- Add preview support for Krita (`.kra`) and OpenRaster (`.ora`) files
- Both formats are ZIP archives containing a `mergedimage.png` (the flattened composite)
- Extracts and displays the preview image using the existing `zip` crate — no new dependencies
- Icon mapping for `.kra` was already present in `icon_theme.rs`

## Test plan

- [x] `cargo check` passes
- [x] Open a `.kra` file — displays the flattened preview image correctly
- [ ] Open an `.ora` file — same behavior
- [ ] Files without `mergedimage.png` show a parse error

---

This code was authored by Claude (Anthropic AI assistant), prompted by @nabaxo.