### PR TITLE
feat: add default Space shortcut to KIO service menu

### DIFF
--- a/data/kglance-rust.desktop
+++ b/data/kglance-rust.desktop
@@ -10,3 +10,4 @@ Exec=kglance %F
 Name=Quick Preview
 Icon=kglance
 Exec=kglance %F
+X-KDE-Shortcuts=Space


### PR DESCRIPTION
## Summary

- Add `X-KDE-Shortcuts=Space` to the service menu desktop action
- Dolphin preserves the Space shortcut across reinstalls and updates without requiring manual reconfiguration

🤖 Generated with [Claude Code](https://claude.com/claude-code)