### PR TITLE
feat: auto-generate JSON schema for config validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1380,6 +1380,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3165,7 +3171,7 @@ dependencies = [
 
 [[package]]
 name = "kglance"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "calamine",
  "chrono",
@@ -3192,6 +3198,7 @@ dependencies = [
  "quick-xml",
  "resvg 0.48.1",
  "rustc-hash 2.1.3",
+ "schemars",
  "serde",
  "serde_json",
  "sevenz-rust",
@@ -5174,6 +5181,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5238,6 +5269,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ url = "2"
 docx-rs = "0.4"
 calamine = "0.36"
 fontdue = "0.9"
+schemars = { version = "0.8", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 notify = "8.2.0"
@@ -84,6 +85,7 @@ rustc-hash = "2.1.3"
 [features]
 default = ["7z"]
 7z = ["sevenz-rust"]
+schema = ["schemars"]
 
 [package.metadata.deb]
 maintainer = "mintori <mintori@users.noreply.github.com>"

--- a/data/examples/config.example.json
+++ b/data/examples/config.example.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "./config.schema.json",
   "ui": {
     "theme": "Dark",
     "font_size": 14.0,

--- a/data/examples/config.schema.json
+++ b/data/examples/config.schema.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "AppConfig",
+  "type": "object",
+  "required": [
+    "ui"
+  ],
+  "properties": {
+    "$schema": {
+      "default": "https://raw.githubusercontent.com/Mintori09/kglance/main/data/examples/config.schema.json",
+      "type": "string"
+    },
+    "ui": {
+      "$ref": "#/definitions/UiConfig"
+    }
+  },
+  "definitions": {
+    "UiConfig": {
+      "type": "object",
+      "required": [
+        "default_height",
+        "default_width",
+        "font_size"
+      ],
+      "properties": {
+        "default_height": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "default_width": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "epub_font_family": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "font_family": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "font_family_mono": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "font_size": {
+          "type": "number",
+          "format": "float"
+        },
+        "json_tree_view": {
+          "default": true,
+          "type": "boolean"
+        },
+        "max_text_width": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "float"
+        },
+        "min_height": {
+          "default": 600,
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "min_width": {
+          "default": 800,
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "prefer_mermaid_cli": {
+          "default": false,
+          "type": "boolean"
+        },
+        "theme": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "word_wrap": {
+          "default": false,
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -4,6 +4,7 @@ use std::fs;
 use std::path::PathBuf;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct UiConfig {
     pub theme: Option<String>,
     pub font_size: f32,
@@ -27,6 +28,11 @@ pub struct UiConfig {
 
 fn default_json_tree_view() -> bool {
     true
+}
+
+fn default_schema() -> String {
+    "https://raw.githubusercontent.com/Mintori09/kglance/main/data/examples/config.schema.json"
+        .to_string()
 }
 
 fn default_min_width() -> u32 {
@@ -92,9 +98,21 @@ impl Default for UiConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct AppConfig {
+    #[serde(rename = "$schema", default = "default_schema")]
+    pub schema: String,
     pub ui: UiConfig,
+}
+
+impl Default for AppConfig {
+    fn default() -> Self {
+        Self {
+            schema: default_schema(),
+            ui: UiConfig::default(),
+        }
+    }
 }
 
 pub struct ConfigManager;

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -57,6 +57,7 @@ fn test_config_serialization_round_trip() {
             word_wrap: false,
             json_tree_view: false,
         },
+        ..Default::default()
     };
     let json = serde_json::to_string_pretty(&config).unwrap();
     let deserialized: AppConfig = serde_json::from_str(&json).unwrap();
@@ -70,6 +71,7 @@ fn test_get_theme_light() {
             theme: Some("Light".into()),
             ..Default::default()
         },
+        ..Default::default()
     };
     assert_eq!(ConfigManager::get_theme_setting(&config), "Light");
     assert_eq!(ConfigManager::resolve_theme("Light"), AppTheme::Light);
@@ -82,6 +84,7 @@ fn test_get_theme_dark() {
             theme: Some("Dark".into()),
             ..Default::default()
         },
+        ..Default::default()
     };
     assert_eq!(ConfigManager::get_theme_setting(&config), "Dark");
     assert_eq!(ConfigManager::resolve_theme("Dark"), AppTheme::Dark);
@@ -94,6 +97,7 @@ fn test_get_theme_nord() {
             theme: Some("Nord".into()),
             ..Default::default()
         },
+        ..Default::default()
     };
     assert_eq!(ConfigManager::get_theme_setting(&config), "Nord");
     assert_eq!(ConfigManager::resolve_theme("Nord"), AppTheme::Nord);
@@ -106,6 +110,7 @@ fn test_get_theme_auto() {
             theme: Some("auto".into()),
             ..Default::default()
         },
+        ..Default::default()
     };
     let theme_setting = ConfigManager::get_theme_setting(&config);
     assert_eq!(theme_setting, "auto");
@@ -152,6 +157,7 @@ fn test_save_load_and_create_default() {
                 font_family: Some("Fira Sans".into()),
                 ..Default::default()
             },
+            ..Default::default()
         };
 
         ConfigManager::save(&original).unwrap();

--- a/tests/schema_test.rs
+++ b/tests/schema_test.rs
@@ -1,0 +1,27 @@
+//! Run with: cargo test --features schema generate_config_schema
+
+#[test]
+fn generate_config_schema() {
+    #[cfg(not(feature = "schema"))]
+    {
+        eprintln!("Skipped: run with --features schema");
+        return;
+    }
+
+    #[cfg(feature = "schema")]
+    {
+        let schema = schemars::schema_for!(kglance::core::config::AppConfig);
+        let json = serde_json::to_string_pretty(&schema).unwrap();
+
+        let path = std::path::Path::new("data/examples/config.schema.json");
+        let current = std::fs::read_to_string(path).unwrap_or_default();
+
+        if current != json {
+            std::fs::write(path, &json).unwrap();
+            panic!(
+                "Schema was out of date and has been regenerated. \
+                 Run `cargo test --features schema` again to verify."
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add `schemars` as optional dependency behind `schema` feature flag (zero runtime cost)
- Derive `JsonSchema` on `AppConfig` and `UiConfig` structs
- Auto-generate `data/examples/config.schema.json` from Rust types via test
- Auto-inject `$schema` URL into user's `config.json` on next load, enabling editor autocompletion and validation
- Regenerate with: `cargo test --features schema --test schema_test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)