### PR TITLE
feat: remember window size across sessions

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -84,10 +84,13 @@ impl KglanceApp {
             font_family_mono: config.ui.font_family_mono,
             epub_font_family: config.ui.epub_font_family,
             max_text_width: config.ui.max_text_width,
-            window_default_size: iced::Size::new(
-                config.ui.default_width as f32,
-                config.ui.default_height as f32,
-            ),
+            window_default_size: {
+                let saved = crate::core::window_state::load();
+                iced::Size::new(
+                    saved.as_ref().map_or(config.ui.default_width as f32, |s| s.width),
+                    saved.as_ref().map_or(config.ui.default_height as f32, |s| s.height),
+                )
+            },
             window_min_size: iced::Size::new(
                 config.ui.min_width as f32,
                 config.ui.min_height as f32,

--- a/src/app/window.rs
+++ b/src/app/window.rs
@@ -54,6 +54,10 @@ impl KglanceApp {
             self.state.read_positions_dirty = false;
         }
 
+        if self.state.window_width > 0.0 && self.state.window_height > 0.0 {
+            crate::core::window_state::save(self.state.window_width, self.state.window_height);
+        }
+
         self.video = None;
 
         if self.is_daemon {
@@ -150,6 +154,8 @@ impl KglanceApp {
             WindowEvent::CloseRequested => self.handle_window_close_requested(window_id),
             WindowEvent::Resized(size) => {
                 if size.width > 0.0 && size.height > 0.0 {
+                    self.state.window_width = size.width;
+                    self.state.window_height = size.height;
                     self.update_grid_cols(size.width, size.height);
                 }
                 Task::none()
@@ -179,6 +185,8 @@ impl KglanceApp {
             self.state.window_default_size.height
         };
 
+        self.state.window_width = width;
+        self.state.window_height = height;
         self.update_grid_cols(width, height);
 
         if let Some(content) = self
@@ -196,6 +204,9 @@ impl KglanceApp {
     }
 
     fn handle_window_close_requested(&mut self, window_id: window::Id) -> Task<Message> {
+        if self.state.window_width > 0.0 && self.state.window_height > 0.0 {
+            crate::core::window_state::save(self.state.window_width, self.state.window_height);
+        }
         self.video = None;
         if self.is_daemon {
             self.current_content = None;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -10,6 +10,7 @@ pub mod preview;
 pub mod read_positions;
 pub mod types;
 pub mod utils;
+pub mod window_state;
 
 pub use cache::CachedContent;
 pub use preview::{FilePreviewer, PreviewData};

--- a/src/core/window_state.rs
+++ b/src/core/window_state.rs
@@ -1,0 +1,38 @@
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WindowState {
+    pub width: f32,
+    pub height: f32,
+}
+
+fn state_path() -> PathBuf {
+    let base = dirs::state_dir()
+        .or_else(|| dirs::data_local_dir().map(|d| d.join("state")))
+        .unwrap_or_else(|| {
+            dirs::home_dir()
+                .unwrap_or_default()
+                .join(".local")
+                .join("state")
+        });
+    base.join("kglance").join("window.json")
+}
+
+pub fn load() -> Option<WindowState> {
+    let path = state_path();
+    let content = fs::read_to_string(&path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+pub fn save(width: f32, height: f32) {
+    let path = state_path();
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let state = WindowState { width, height };
+    if let Ok(json) = serde_json::to_string_pretty(&state) {
+        let _ = fs::write(&path, json);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,17 +149,17 @@ fn run_standalone(paths: &[String]) -> Result<(), Box<dyn std::error::Error>> {
 
     let primary = &paths[0];
     let resolved = std::path::Path::new(primary);
-    let mut initial_size = Size::new(
-        config.ui.default_width as f32,
-        config.ui.default_height as f32,
-    );
+    let saved_size = kglance::core::window_state::load();
+    let base_width = saved_size.as_ref().map_or(config.ui.default_width as f32, |s| s.width);
+    let base_height = saved_size.as_ref().map_or(config.ui.default_height as f32, |s| s.height);
+    let mut initial_size = Size::new(base_width, base_height);
 
     if let Ok(kglance::parsers::ParsedContent::Image { width, height, .. }) =
         registry.parse(resolved)
     {
         initial_size = kglance::features::image::view::calculate_window_size(
-            config.ui.default_width as f32,
-            config.ui.default_height as f32,
+            base_width,
+            base_height,
             width,
             height,
         );


### PR DESCRIPTION
## Summary

- Save window dimensions to `~/.local/state/kglance/window.json` on close
- Restore saved size on next launch (both standalone and daemon modes)
- Uses XDG state directory instead of polluting user's `config.json`
- Falls back to config defaults when no saved state exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)