### PR TITLE
feat: add PageUp/PageDown keys for file navigation

### DIFF
--- a/src/app/keyboard/mod.rs
+++ b/src/app/keyboard/mod.rs
@@ -161,6 +161,16 @@ impl super::KglanceApp {
                             ))
                         }
                     }
+                    iced::keyboard::Key::Named(Named::PageDown) => {
+                        Some(self.update(
+                            crate::app::messages::NavigationMsg::NextFileClicked.into(),
+                        ))
+                    }
+                    iced::keyboard::Key::Named(Named::PageUp) => {
+                        Some(self.update(
+                            crate::app::messages::NavigationMsg::PrevFileClicked.into(),
+                        ))
+                    }
                     _ => None,
                 }
             }

--- a/src/core/navigation.rs
+++ b/src/core/navigation.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 pub const SUPPORTED_EXTS: &[&str] = &[
     "png", "jpg", "jpeg", "gif", "webp", "svg", "bmp", "txt", "md", "typ", "rs", "py", "js", "ts",
     "json", "toml", "yaml", "pdf", "mp4", "mkv", "avi", "webm", "mp3", "wav", "flac", "csv", "tsv",
-    "xlsx", "epub",
+    "xlsx", "epub", "desktop",
 ];
 
 pub fn is_supported_path(path: &Path) -> bool {

--- a/src/ui/components/code_editor.rs
+++ b/src/ui/components/code_editor.rs
@@ -1,6 +1,6 @@
 use iced::alignment::{Horizontal, Vertical};
 use iced::highlighter::Theme as HighlightTheme;
-use iced::widget::text_editor::{Action, Content};
+use iced::widget::text_editor::{Action, Binding, Content, KeyPress};
 use iced::widget::{container, row, text, text_editor};
 use iced::{Alignment, Element, Font, Length};
 
@@ -109,6 +109,16 @@ pub fn code_editor<'a>(
             iced::widget::text::Wrapping::None
         })
         .on_action(on_action)
+        .key_binding(|key_press: KeyPress| {
+            use iced::keyboard::key::Named;
+            if matches!(
+                key_press.key.as_ref(),
+                iced::keyboard::Key::Named(Named::PageUp | Named::PageDown)
+            ) {
+                return None;
+            }
+            Binding::from_key_press(key_press)
+        })
         .style(default_text_editor);
 
     if word_wrap {


### PR DESCRIPTION
## Summary
- PageUp/PageDown navigate to previous/next file in detail view, regardless of content type
- Text editor's `key_binding` callback suppresses PageUp/PageDown so they propagate to the app-level handler instead of being captured by the editor widget

## Test plan
- [ ] Open any text file in detail view, press PageDown → navigates to next file
- [ ] Press PageUp → navigates to previous file
- [ ] Open .desktop file, verify PageUp/PageDown navigate between files
- [ ] Open non-text content (image, PDF), verify PageUp/PageDown still work
- [ ] Arrow keys remain unchanged (still scroll text / seek video / navigate epub)

🤖 Generated with [Claude Code](https://claude.com/claude-code)